### PR TITLE
Capture geolocation on startup

### DIFF
--- a/lib/screens/evidence_screen.dart
+++ b/lib/screens/evidence_screen.dart
@@ -102,7 +102,9 @@ class _EvidenceScreenState extends State<EvidenceScreen> {
                     dateTime: DateTime.now(),
                     okolnost: _selectedOkolnost,
                     trajanje: _selectedTrajanje,
-                    geolokacija: 'dummy',
+                    geolokacija:
+                        Provider.of<AppState>(context, listen: false)
+                            .currentLocation,
                     healthData: healthData,
                   ),
                 );
@@ -135,7 +137,9 @@ class _EvidenceScreenState extends State<EvidenceScreen> {
                     dateTime: DateTime.now(),
                     okolnost: _selectedOkolnost,
                     trajanje: _selectedTrajanje,
-                    geolokacija: 'dummy',
+                    geolokacija:
+                        Provider.of<AppState>(context, listen: false)
+                            .currentLocation,
                     healthData: healthData,
                   ),
                 );
@@ -169,7 +173,9 @@ class _EvidenceScreenState extends State<EvidenceScreen> {
                     dateTime: DateTime.now(),
                     okolnost: _selectedOkolnost,
                     trajanje: _selectedTrajanje,
-                    geolokacija: 'dummy',
+                    geolokacija:
+                        Provider.of<AppState>(context, listen: false)
+                            .currentLocation,
                     healthData: healthData,
                   ),
                 );
@@ -203,7 +209,9 @@ class _EvidenceScreenState extends State<EvidenceScreen> {
                     dateTime: DateTime.now(),
                     okolnost: _selectedOkolnost,
                     trajanje: _selectedTrajanje,
-                    geolokacija: 'dummy',
+                    geolokacija:
+                        Provider.of<AppState>(context, listen: false)
+                            .currentLocation,
                     healthData: healthData,
                   ),
                 );

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:geolocator/geolocator.dart';
 
 class Event {
   final String type;
@@ -28,12 +29,15 @@ class Event {
 class AppState extends ChangeNotifier {
   bool _showTestTab = false;
   double? _height;
+  String? _currentLocation;
 
   bool get showTestTab => _showTestTab;
   double? get height => _height;
+  String? get currentLocation => _currentLocation;
 
   AppState() {
     _loadHeight();
+    _initLocation();
   }
 
   Future<void> _loadHeight() async {
@@ -52,6 +56,24 @@ class AppState extends ChangeNotifier {
   void setShowTestTab(bool value) {
     _showTestTab = value;
     notifyListeners();
+  }
+
+  Future<void> _initLocation() async {
+    bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) return;
+
+    LocationPermission permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) return;
+    }
+    if (permission == LocationPermission.deniedForever) return;
+
+    try {
+      final pos = await Geolocator.getCurrentPosition();
+      _currentLocation = '${pos.latitude},${pos.longitude}';
+      notifyListeners();
+    } catch (_) {}
   }
 
   // Lista događaja


### PR DESCRIPTION
## Summary
- track location in `AppState` using geolocator
- use the stored location when creating events

## Testing
- `flutter format lib/state/app_state.dart lib/screens/evidence_screen.dart` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842134ba864832fae35fd35764ceb63