### PR TITLE
Add reusable toast widget

### DIFF
--- a/lib/widgets/app_toast.dart
+++ b/lib/widgets/app_toast.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:another_flushbar/flushbar.dart';
+
+class AppToast {
+  static void show(
+    BuildContext context, {
+    required String message,
+    Duration duration = const Duration(seconds: 3),
+    VoidCallback? onUndo,
+    bool showUndo = true,
+  }) {
+    late Flushbar<dynamic> flush;
+    flush = Flushbar<dynamic>(
+      messageText: Text(
+        message,
+        style: const TextStyle(color: Colors.white),
+      ),
+      flushbarPosition: FlushbarPosition.BOTTOM,
+      backgroundColor: Colors.black87,
+      margin: const EdgeInsets.all(8),
+      borderRadius: BorderRadius.circular(8),
+      duration: duration,
+      mainButton: showUndo
+          ? TextButton(
+              onPressed: () {
+                flush.dismiss();
+                onUndo?.call();
+              },
+              child: const Text(
+                'Undo',
+                style: TextStyle(color: Colors.yellow),
+              ),
+            )
+          : null,
+      onTap: (bar) {
+        bar.dismiss();
+      },
+    );
+
+    flush.show(context);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AppToast` widget using `another_flushbar`
- revert changes in `EvidenceScreen` so it still uses SnackBar
- fix toast initialization to avoid early reference

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420ec67bec832f987c6ffbdaee1566