### PR TITLE
Add daily therapy time selection

### DIFF
--- a/lib/screens/daily_therapy_screen.dart
+++ b/lib/screens/daily_therapy_screen.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
+import '../widgets/custom_button.dart';
+
+class DailyTherapyScreen extends StatefulWidget {
+  const DailyTherapyScreen({super.key});
+
+  @override
+  State<DailyTherapyScreen> createState() => _DailyTherapyScreenState();
+}
+
+class _DailyTherapyScreenState extends State<DailyTherapyScreen> {
+  Future<DateTime?> _selectTime(BuildContext context) async {
+    TimeOfDay initial = TimeOfDay.now();
+    final picked = await showModalBottomSheet<TimeOfDay>(
+      context: context,
+      builder: (context) {
+        TimeOfDay temp = initial;
+        return Container(
+          padding: const EdgeInsets.all(16),
+          height: 250,
+          child: Column(
+            children: [
+              Expanded(
+                child: CupertinoDatePicker(
+                  mode: CupertinoDatePickerMode.time,
+                  use24hFormat: true,
+                  initialDateTime:
+                      DateTime(0, 0, 0, initial.hour, initial.minute),
+                  onDateTimeChanged: (dt) {
+                    temp = TimeOfDay(hour: dt.hour, minute: dt.minute);
+                  },
+                ),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(temp),
+                child: const Text('Potvrdi'),
+              )
+            ],
+          ),
+        );
+      },
+    );
+
+    if (picked == null) return null;
+    final now = DateTime.now();
+    return DateTime(now.year, now.month, now.day, picked.hour, picked.minute);
+  }
+
+  void _recordTherapy(String label, DateTime time) {
+    final msg = '$label u ${_formatTime(time)}';
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
+  }
+
+  String _formatTime(DateTime time) {
+    return '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dnevna terapija')),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            CustomButton(
+              label: 'Jutarnja terapija',
+              icon: Icons.light_mode_outlined,
+              backgroundColor: Colors.deepPurpleAccent,
+              onPressed: () {
+                _recordTherapy('Jutarnja terapija', DateTime.now());
+              },
+              onLongPress: () async {
+                final time = await _selectTime(context);
+                if (time != null) {
+                  _recordTherapy('Jutarnja terapija', time);
+                }
+              },
+            ),
+            const SizedBox(height: 20),
+            CustomButton(
+              label: 'Večernja terapija',
+              icon: Icons.dark_mode_outlined,
+              backgroundColor: Colors.indigo,
+              onPressed: () {
+                _recordTherapy('Večernja terapija', DateTime.now());
+              },
+              onLongPress: () async {
+                final time = await _selectTime(context);
+                if (time != null) {
+                  _recordTherapy('Večernja terapija', time);
+                }
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/main_navigator.dart
+++ b/lib/screens/main_navigator.dart
@@ -4,6 +4,7 @@ import 'test_screen.dart';
 import 'history_screen.dart';
 import '../state/app_state.dart';
 import 'evidence_screen.dart';
+import 'daily_therapy_screen.dart';
 
 
 class MainNavigator extends StatefulWidget {
@@ -20,19 +21,21 @@ class _MainNavigatorState extends State<MainNavigator> {
   Widget build(BuildContext context) {
     final showTest = context.watch<AppState>().showTestTab;
 
-    // If the test tab is disabled while it was active, reset to the first tab
-    if (!showTest && _currentIndex >= 2) {
-      _currentIndex = 0;
-    }
-
     final screens = [
       const EvidenceScreen(),
+      const DailyTherapyScreen(),
       const HistoryScreen(),
       if (showTest) const TestScreen(),
     ];
 
+    // If the test tab is disabled while it was active, reset to the first tab
+    if (_currentIndex >= screens.length) {
+      _currentIndex = 0;
+    }
+
     final items = [
       const BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Početna'),
+      const BottomNavigationBarItem(icon: Icon(Icons.medication), label: 'Terapija'),
       const BottomNavigationBarItem(icon: Icon(Icons.history), label: 'Istorija'),
       if (showTest)
         const BottomNavigationBarItem(icon: Icon(Icons.science), label: 'Test'),

--- a/lib/widgets/custom_button.dart
+++ b/lib/widgets/custom_button.dart
@@ -5,6 +5,7 @@ class CustomButton extends StatefulWidget {
   final String label;
   final IconData icon;
   final VoidCallback onPressed;
+  final VoidCallback? onLongPress;
   final Color backgroundColor;
   final Color textColor;
   final double borderRadius;
@@ -17,6 +18,7 @@ class CustomButton extends StatefulWidget {
     required this.label,
     required this.icon,
     required this.onPressed,
+    this.onLongPress,
     this.backgroundColor = Colors.grey,
     this.textColor = Colors.white,
     this.borderRadius = 12,
@@ -52,6 +54,7 @@ class _CustomButtonState extends State<CustomButton> {
         height: widget.height,
         child: ElevatedButton.icon(
           onPressed: widget.onPressed,
+          onLongPress: widget.onLongPress,
           icon: Icon(widget.icon, color: widget.textColor),
           label: Text(
             widget.label,


### PR DESCRIPTION
## Summary
- support optional long press handler in CustomButton
- add DailyTherapyScreen with bottom sheet time picker
- update MainNavigator to include therapy screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433081fe28832f838006c00b226938